### PR TITLE
Add kodein module

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,57 @@
+name: Java Build & Publish
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    name: Build and Publish with Java 21
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Java 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 21
+          cache: gradle
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: Build project
+        run: ./gradlew build --no-daemon
+
+      - name: Check for 'internal' PR label
+        id: check_label
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        uses: actions/github-script@v7
+        with:
+          result-encoding: string
+          script: |
+            const commitSha = context.sha;
+            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: commitSha
+            });
+
+            if (prs.length === 0) {
+              core.info("No PR found for this commit.");
+              return "";
+            }
+
+            const labels = prs[0].labels.map(label => label.name);
+            core.info(`Labels found: ${labels.join(", ")}`);
+            return labels.join(","); // Return as comma-separated string
+
+      - name: Publish to GitHub Packages
+        if: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' && !contains(steps.check_label.outputs.result, 'internal') }}
+        run: ./gradlew publish --no-daemon
+        env:
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build
 
 .idea
 .kotlin
+kls_database.db

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,12 +7,16 @@ guava = "33.4.5-jre"
 junit-jupiter-engine = "5.12.1"
 dropwizard = "4.0.15"
 kotlinter = "5.1.1"
+classgraph = "4.8.181"
+kodein = "7.26.1"
 
 [libraries]
 commons-math3 = { module = "org.apache.commons:commons-math3", version.ref = "commons-math3" }
 guava = { module = "com.google.guava:guava", version.ref = "guava" }
 junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit-jupiter-engine" }
 dropwizard-core = { module = "io.dropwizard:dropwizard-core", version.ref = "dropwizard" }
+classgraph = { module = "io.github.classgraph:classgraph", version.ref = "classgraph" }
+kodein = { module = "org.kodein.di:kodein-di", version.ref = "kodein" }
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version = "2.1.20" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,7 @@ junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", vers
 dropwizard-core = { module = "io.dropwizard:dropwizard-core", version.ref = "dropwizard" }
 classgraph = { module = "io.github.classgraph:classgraph", version.ref = "classgraph" }
 kodein = { module = "org.kodein.di:kodein-di", version.ref = "kodein" }
+dropwizard-testing = { module = "io.dropwizard:dropwizard-testing", version.ref = "dropwizard" }
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version = "2.1.20" }

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -13,6 +13,7 @@ plugins {
 
     // Apply the java-library plugin for API and implementation separation.
     `java-library`
+    `maven-publish`
 }
 
 repositories {
@@ -51,4 +52,17 @@ java {
 tasks.named<Test>("test") {
     // Use JUnit Platform for unit tests.
     useJUnitPlatform()
+}
+
+publishing {
+    repositories {
+        maven {
+            name = "GitHubPackages"
+            url = uri("https://maven.pkg.github.com/saths008/dropwizard-kodein")
+            credentials {
+                username = System.getenv("GITHUB_ACTOR")
+                password = System.getenv("GITHUB_TOKEN")
+            }
+        }
+    }
 }

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -36,6 +36,8 @@ dependencies {
     implementation(libs.guava)
 
     implementation(libs.dropwizard.core)
+    implementation(libs.classgraph)
+    implementation(libs.kodein)
 }
 
 // Apply a specific Java toolchain to ease working on different environments.

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -38,6 +38,7 @@ dependencies {
     implementation(libs.dropwizard.core)
     implementation(libs.classgraph)
     implementation(libs.kodein)
+    testImplementation(libs.dropwizard.testing)
 }
 
 // Apply a specific Java toolchain to ease working on different environments.

--- a/lib/src/main/kotlin/dev/saath/dropwizard/kodein/ConfigurationAwareModuleInterface.kt
+++ b/lib/src/main/kotlin/dev/saath/dropwizard/kodein/ConfigurationAwareModuleInterface.kt
@@ -1,0 +1,12 @@
+package dev.saath.dropwizard.kodein
+
+import io.dropwizard.core.Configuration
+
+interface ConfigurationAwareModuleInterface {
+    /**
+     * Method will be called just before injector initialization.
+     *
+     * @param configuration configuration object
+     */
+    fun setConfiguration(configuration: Configuration)
+}

--- a/lib/src/main/kotlin/dev/saath/dropwizard/kodein/KodeinBundle.kt
+++ b/lib/src/main/kotlin/dev/saath/dropwizard/kodein/KodeinBundle.kt
@@ -1,5 +1,33 @@
 package dev.saath.dropwizard.kodein
 
-class KodeinBundle {
-    fun someLibraryMethod(): Boolean = true
+import dev.saath.dropwizard.kodein.installers.InstallerInterface
+import dev.saath.dropwizard.kodein.installers.ResourceInstaller
+import io.dropwizard.core.Configuration
+import io.dropwizard.core.ConfiguredBundle
+import io.dropwizard.core.setup.Bootstrap
+import io.dropwizard.core.setup.Environment
+import io.github.classgraph.ClassGraph
+import io.github.classgraph.ClassGraphException
+import io.github.classgraph.ScanResult
+import org.kodein.di.DI
+import kotlin.jvm.Throws
+
+class KodeinBundle : ConfiguredBundle<Configuration> {
+    val di: DI = DI {}
+
+    override fun initialize(bootstrap: Bootstrap<*>?) {
+    }
+
+    override fun run(
+        configuration: Configuration?,
+        environment: Environment?,
+    ) {
+        val scanRes = searchClassPath()
+        listOf<InstallerInterface>(ResourceInstaller(scanRes)).forEach { installer ->
+            installer.install(di, environment!!, installer.search())
+        }
+    }
+
+    @Throws(ClassGraphException::class)
+    fun searchClassPath(): ScanResult = ClassGraph().enableClassInfo().scan()
 }

--- a/lib/src/main/kotlin/dev/saath/dropwizard/kodein/KodeinBundle.kt
+++ b/lib/src/main/kotlin/dev/saath/dropwizard/kodein/KodeinBundle.kt
@@ -29,5 +29,5 @@ class KodeinBundle : ConfiguredBundle<Configuration> {
     }
 
     @Throws(ClassGraphException::class)
-    fun searchClassPath(): ScanResult = ClassGraph().enableClassInfo().scan()
+    fun searchClassPath(): ScanResult = ClassGraph().enableClassInfo().enableAnnotationInfo().scan()
 }

--- a/lib/src/main/kotlin/dev/saath/dropwizard/kodein/KodeinBundle.kt
+++ b/lib/src/main/kotlin/dev/saath/dropwizard/kodein/KodeinBundle.kt
@@ -1,6 +1,6 @@
 package dev.saath.dropwizard.kodein
 
-import dev.saath.dropwizard.kodein.installers.InstallerInterface
+import dev.saath.dropwizard.kodein.installers.AutoScanInstallerInterface
 import dev.saath.dropwizard.kodein.installers.ResourceInstaller
 import io.dropwizard.core.Configuration
 import io.dropwizard.core.ConfiguredBundle
@@ -12,19 +12,23 @@ import io.github.classgraph.ScanResult
 import org.kodein.di.DI
 import kotlin.jvm.Throws
 
-class KodeinBundle : ConfiguredBundle<Configuration> {
-    val di: DI = DI {}
+class KodeinBundle(
+    diModules: List<DI.Module>,
+) : ConfiguredBundle<Configuration> {
+    val di: DI =
+        DI {
+            diModules.forEach { import(it) }
+        }
 
-    override fun initialize(bootstrap: Bootstrap<*>?) {
-    }
+    override fun initialize(bootstrap: Bootstrap<*>?) {}
 
     override fun run(
         configuration: Configuration?,
         environment: Environment?,
     ) {
         val scanRes = searchClassPath()
-        listOf<InstallerInterface>(ResourceInstaller(scanRes)).forEach { installer ->
-            installer.install(di, environment!!, installer.search())
+        listOf<AutoScanInstallerInterface>(ResourceInstaller()).forEach { installer ->
+            installer.install(di, environment!!, installer.search(scanRes))
         }
     }
 

--- a/lib/src/main/kotlin/dev/saath/dropwizard/kodein/KodeinBundle.kt
+++ b/lib/src/main/kotlin/dev/saath/dropwizard/kodein/KodeinBundle.kt
@@ -1,7 +1,7 @@
 package dev.saath.dropwizard.kodein
 
-import dev.saath.dropwizard.kodein.installers.AutoScanInstallerInterface
-import dev.saath.dropwizard.kodein.installers.ResourceInstaller
+import dev.saath.dropwizard.kodein.installers.autoscanner.AutoScanInstallerInterface
+import dev.saath.dropwizard.kodein.installers.autoscanner.ResourceInstaller
 import io.dropwizard.core.Configuration
 import io.dropwizard.core.ConfiguredBundle
 import io.dropwizard.core.setup.Bootstrap

--- a/lib/src/main/kotlin/dev/saath/dropwizard/kodein/KodeinDropwizardModuleInterface.kt
+++ b/lib/src/main/kotlin/dev/saath/dropwizard/kodein/KodeinDropwizardModuleInterface.kt
@@ -1,0 +1,7 @@
+package dev.saath.dropwizard.kodein
+
+import org.kodein.di.DI
+
+interface KodeinDropwizardModuleInterface {
+    fun configure(): DI.Module
+}

--- a/lib/src/main/kotlin/dev/saath/dropwizard/kodein/installers/InstallerInterface.kt
+++ b/lib/src/main/kotlin/dev/saath/dropwizard/kodein/installers/InstallerInterface.kt
@@ -1,30 +1,35 @@
 package dev.saath.dropwizard.kodein.installers
 
 import io.dropwizard.core.setup.Environment
+import io.github.classgraph.ScanResult
+import org.kodein.di.BindingsMap
 import org.kodein.di.DI
 import org.kodein.di.direct
+import org.kodein.di.instance
 import org.kodein.di.instanceOrNull
 
 interface InstallerInterface {
-    val scanResults: io.github.classgraph.ScanResult
-
-    fun search(): List<Class<*>>
-
     fun install(
         di: DI,
         environment: Environment,
         clazzes: List<Class<*>>,
     ) {
         clazzes.forEach { clazz ->
-            try {
-                val resource = di.direct.instanceOrNull<Any>(tag = clazz.name)
-                environment.jersey().register(resource!!)
-            } catch (exception: Exception) {
-                println(
-                    "==========================================KodeinBundle==========================================",
-                )
-                println("Failed to register: ${clazz.simpleName}: ${exception.message}")
-            }
+            val resource = di.direct.instance<Any>(tag = clazz.name)
+            println("resource name: ${resource::class.simpleName}")
+            environment.jersey().register(resource)
         }
     }
+}
+
+interface AutoScanInstallerInterface : InstallerInterface {
+    fun search(scanResults: ScanResult): List<Class<*>>
+}
+
+/**
+ * DIScanInstallerInterface represents installers that look through
+ * Kodein's container tree to install dependecies
+ */
+interface DIScanInstallerInterface : InstallerInterface {
+    fun search(bindings: BindingsMap): List<Class<*>>
 }

--- a/lib/src/main/kotlin/dev/saath/dropwizard/kodein/installers/InstallerInterface.kt
+++ b/lib/src/main/kotlin/dev/saath/dropwizard/kodein/installers/InstallerInterface.kt
@@ -3,7 +3,7 @@ package dev.saath.dropwizard.kodein.installers
 import io.dropwizard.core.setup.Environment
 import org.kodein.di.DI
 import org.kodein.di.direct
-import org.kodein.di.instance
+import org.kodein.di.instanceOrNull
 
 interface InstallerInterface {
     val scanResults: io.github.classgraph.ScanResult
@@ -17,9 +17,12 @@ interface InstallerInterface {
     ) {
         clazzes.forEach { clazz ->
             try {
-                di.direct.instance<Any>(clazz.kotlin)
-                environment.jersey().register(clazz)
+                val resource = di.direct.instanceOrNull<Any>(tag = clazz.name)
+                environment.jersey().register(resource!!)
             } catch (exception: Exception) {
+                println(
+                    "==========================================KodeinBundle==========================================",
+                )
                 println("Failed to register: ${clazz.simpleName}: ${exception.message}")
             }
         }

--- a/lib/src/main/kotlin/dev/saath/dropwizard/kodein/installers/InstallerInterface.kt
+++ b/lib/src/main/kotlin/dev/saath/dropwizard/kodein/installers/InstallerInterface.kt
@@ -1,0 +1,27 @@
+package dev.saath.dropwizard.kodein.installers
+
+import io.dropwizard.core.setup.Environment
+import org.kodein.di.DI
+import org.kodein.di.direct
+import org.kodein.di.instance
+
+interface InstallerInterface {
+    val scanResults: io.github.classgraph.ScanResult
+
+    fun search(): List<Class<*>>
+
+    fun install(
+        di: DI,
+        environment: Environment,
+        clazzes: List<Class<*>>,
+    ) {
+        clazzes.forEach { clazz ->
+            try {
+                di.direct.instance<Any>(clazz.kotlin)
+                environment.jersey().register(clazz)
+            } catch (exception: Exception) {
+                println("Failed to register: ${clazz.simpleName}: ${exception.message}")
+            }
+        }
+    }
+}

--- a/lib/src/main/kotlin/dev/saath/dropwizard/kodein/installers/InstallerInterface.kt
+++ b/lib/src/main/kotlin/dev/saath/dropwizard/kodein/installers/InstallerInterface.kt
@@ -1,12 +1,9 @@
 package dev.saath.dropwizard.kodein.installers
 
 import io.dropwizard.core.setup.Environment
-import io.github.classgraph.ScanResult
-import org.kodein.di.BindingsMap
 import org.kodein.di.DI
 import org.kodein.di.direct
 import org.kodein.di.instance
-import org.kodein.di.instanceOrNull
 
 interface InstallerInterface {
     fun install(
@@ -20,16 +17,4 @@ interface InstallerInterface {
             environment.jersey().register(resource)
         }
     }
-}
-
-interface AutoScanInstallerInterface : InstallerInterface {
-    fun search(scanResults: ScanResult): List<Class<*>>
-}
-
-/**
- * DIScanInstallerInterface represents installers that look through
- * Kodein's container tree to install dependecies
- */
-interface DIScanInstallerInterface : InstallerInterface {
-    fun search(bindings: BindingsMap): List<Class<*>>
 }

--- a/lib/src/main/kotlin/dev/saath/dropwizard/kodein/installers/ResourceInstaller.kt
+++ b/lib/src/main/kotlin/dev/saath/dropwizard/kodein/installers/ResourceInstaller.kt
@@ -5,7 +5,7 @@ import io.github.classgraph.ScanResult
 /**
  * ResourceInstaller does
  */
-const val JAX_RS_PATH_ANNOTATION = "@Path"
+const val JAX_RS_PATH_ANNOTATION = "jakarta.ws.rs.Path"
 
 class ResourceInstaller(
     override val scanResults: ScanResult,

--- a/lib/src/main/kotlin/dev/saath/dropwizard/kodein/installers/ResourceInstaller.kt
+++ b/lib/src/main/kotlin/dev/saath/dropwizard/kodein/installers/ResourceInstaller.kt
@@ -1,0 +1,14 @@
+package dev.saath.dropwizard.kodein.installers
+
+import io.github.classgraph.ScanResult
+
+/**
+ * ResourceInstaller does
+ */
+const val JAX_RS_PATH_ANNOTATION = "@Path"
+
+class ResourceInstaller(
+    override val scanResults: ScanResult,
+) : InstallerInterface {
+    override fun search(): List<Class<*>> = scanResults.getClassesWithAnnotation(JAX_RS_PATH_ANNOTATION).loadClasses()
+}

--- a/lib/src/main/kotlin/dev/saath/dropwizard/kodein/installers/ResourceInstaller.kt
+++ b/lib/src/main/kotlin/dev/saath/dropwizard/kodein/installers/ResourceInstaller.kt
@@ -7,8 +7,7 @@ import io.github.classgraph.ScanResult
  */
 const val JAX_RS_PATH_ANNOTATION = "jakarta.ws.rs.Path"
 
-class ResourceInstaller(
-    override val scanResults: ScanResult,
-) : InstallerInterface {
-    override fun search(): List<Class<*>> = scanResults.getClassesWithAnnotation(JAX_RS_PATH_ANNOTATION).loadClasses()
+class ResourceInstaller : AutoScanInstallerInterface {
+    override fun search(scanResults: ScanResult): List<Class<*>> =
+        scanResults.getClassesWithAnnotation(JAX_RS_PATH_ANNOTATION).loadClasses()
 }

--- a/lib/src/main/kotlin/dev/saath/dropwizard/kodein/installers/autoscanner/AutoScanInstallerInterface.kt
+++ b/lib/src/main/kotlin/dev/saath/dropwizard/kodein/installers/autoscanner/AutoScanInstallerInterface.kt
@@ -1,0 +1,8 @@
+package dev.saath.dropwizard.kodein.installers.autoscanner
+
+import dev.saath.dropwizard.kodein.installers.InstallerInterface
+import io.github.classgraph.ScanResult
+
+interface AutoScanInstallerInterface : InstallerInterface {
+    fun search(scanResults: ScanResult): List<Class<*>>
+}

--- a/lib/src/main/kotlin/dev/saath/dropwizard/kodein/installers/autoscanner/ResourceInstaller.kt
+++ b/lib/src/main/kotlin/dev/saath/dropwizard/kodein/installers/autoscanner/ResourceInstaller.kt
@@ -1,4 +1,4 @@
-package dev.saath.dropwizard.kodein.installers
+package dev.saath.dropwizard.kodein.installers.autoscanner
 
 import io.github.classgraph.ScanResult
 

--- a/lib/src/main/kotlin/dev/saath/dropwizard/kodein/installers/discanner/AllJerseyInstaller.kt
+++ b/lib/src/main/kotlin/dev/saath/dropwizard/kodein/installers/discanner/AllJerseyInstaller.kt
@@ -1,0 +1,23 @@
+package dev.saath.dropwizard.kodein.installers.discanner
+
+import org.kodein.di.BindingsMap
+import org.kodein.di.DI
+import org.kodein.type.jvmType
+
+class AllJerseyInstaller : DIScanInstallerInterface {
+    override fun search(bindings: BindingsMap): List<Class<*>> =
+        bindings
+            .mapNotNull { (key, _) -> key.isRelevantJerseyProvider() }
+}
+
+fun DI.Key<*, *, *>.isRelevantJerseyProvider(): Class<*>? {
+    val rawClass = this.type.jvmType as? Class<*>
+
+    return when (rawClass) {
+        null -> return null
+        this.isResource() -> rawClass
+        this.isFilter() -> rawClass
+        this.isExceptionMapper() -> rawClass
+        else -> return null
+    }
+}

--- a/lib/src/main/kotlin/dev/saath/dropwizard/kodein/installers/discanner/DIScanInstallerInterface.kt
+++ b/lib/src/main/kotlin/dev/saath/dropwizard/kodein/installers/discanner/DIScanInstallerInterface.kt
@@ -1,0 +1,12 @@
+package dev.saath.dropwizard.kodein.installers.discanner
+
+import dev.saath.dropwizard.kodein.installers.InstallerInterface
+import org.kodein.di.BindingsMap
+
+/**
+ * DIScanInstallerInterface represents installers that look through
+ * Kodein's container tree to install dependecies
+ */
+interface DIScanInstallerInterface : InstallerInterface {
+    fun search(bindings: BindingsMap): List<Class<*>>
+}

--- a/lib/src/main/kotlin/dev/saath/dropwizard/kodein/installers/discanner/ExceptionMapperInstaller.kt
+++ b/lib/src/main/kotlin/dev/saath/dropwizard/kodein/installers/discanner/ExceptionMapperInstaller.kt
@@ -1,0 +1,24 @@
+package dev.saath.dropwizard.kodein.installers.discanner
+
+import jakarta.ws.rs.ext.ExceptionMapper
+import org.kodein.di.BindingsMap
+import org.kodein.di.DI
+import org.kodein.type.jvmType
+
+class ExceptionMapperInstaller : DIScanInstallerInterface {
+    override fun search(bindings: BindingsMap): List<Class<*>> =
+        bindings
+            .mapNotNull { (key, _) -> key.isExceptionMapper() }
+}
+
+private fun DI.Key<*, *, *>.isExceptionMapper(): Class<*>? {
+    val rawClass = this.type.jvmType as? Class<*>
+
+    if (rawClass == null ||
+        !ExceptionMapper::class.java.isAssignableFrom(rawClass)
+    ) {
+        return null
+    }
+
+    return rawClass
+}

--- a/lib/src/main/kotlin/dev/saath/dropwizard/kodein/installers/discanner/ExceptionMapperInstaller.kt
+++ b/lib/src/main/kotlin/dev/saath/dropwizard/kodein/installers/discanner/ExceptionMapperInstaller.kt
@@ -11,7 +11,7 @@ class ExceptionMapperInstaller : DIScanInstallerInterface {
             .mapNotNull { (key, _) -> key.isExceptionMapper() }
 }
 
-private fun DI.Key<*, *, *>.isExceptionMapper(): Class<*>? {
+fun DI.Key<*, *, *>.isExceptionMapper(): Class<*>? {
     val rawClass = this.type.jvmType as? Class<*>
 
     if (rawClass == null ||

--- a/lib/src/main/kotlin/dev/saath/dropwizard/kodein/installers/discanner/FilterInstaller.kt
+++ b/lib/src/main/kotlin/dev/saath/dropwizard/kodein/installers/discanner/FilterInstaller.kt
@@ -1,0 +1,28 @@
+package dev.saath.dropwizard.kodein.installers.discanner
+
+import jakarta.ws.rs.container.ContainerRequestFilter
+import jakarta.ws.rs.container.ContainerResponseFilter
+import org.kodein.di.BindingsMap
+import org.kodein.di.DI
+import org.kodein.type.jvmType
+
+class FilterInstaller : DIScanInstallerInterface {
+    override fun search(bindings: BindingsMap): List<Class<*>> =
+        bindings
+            .mapNotNull { (key, _) -> key.isFilter() }
+}
+
+fun DI.Key<*, *, *>.isFilter(): Class<*>? {
+    val rawClass = this.type.jvmType as? Class<*>
+
+    if (rawClass != null &&
+        (
+            ContainerResponseFilter::class.java.isAssignableFrom(rawClass) ||
+                ContainerRequestFilter::class.java.isAssignableFrom(rawClass)
+        )
+    ) {
+        return rawClass
+    }
+
+    return null
+}

--- a/lib/src/main/kotlin/dev/saath/dropwizard/kodein/installers/discanner/ResourceInstaller.kt
+++ b/lib/src/main/kotlin/dev/saath/dropwizard/kodein/installers/discanner/ResourceInstaller.kt
@@ -1,0 +1,24 @@
+package dev.saath.dropwizard.kodein.installers.discanner
+
+import jakarta.ws.rs.Path
+import org.kodein.di.BindingsMap
+import org.kodein.di.DI
+import org.kodein.type.jvmType
+
+class ResourceInstaller : DIScanInstallerInterface {
+    override fun search(bindings: BindingsMap): List<Class<*>> =
+        bindings
+            .mapNotNull { (key, _) -> key.isResource() }
+}
+
+fun DI.Key<*, *, *>.isResource(): Class<*>? {
+    val rawClass = this.type.jvmType as? Class<*>
+
+    if (rawClass != null &&
+        rawClass.isAnnotationPresent(Path::class.java)
+    ) {
+        return rawClass
+    }
+
+    return null
+}

--- a/lib/src/test/kotlin/dev/saath/dropwizard/kodein/KodeinBundleTest.kt
+++ b/lib/src/test/kotlin/dev/saath/dropwizard/kodein/KodeinBundleTest.kt
@@ -8,7 +8,6 @@ import kotlin.test.assertTrue
 
 class KodeinBundleTest {
     @Test fun someLibraryMethodReturnsTrue() {
-        val classUnderTest = KodeinBundle()
         assertTrue(3 == 3, "someLibraryMethod should return 'true'")
     }
 }

--- a/lib/src/test/kotlin/dev/saath/dropwizard/kodein/KodeinBundleTest.kt
+++ b/lib/src/test/kotlin/dev/saath/dropwizard/kodein/KodeinBundleTest.kt
@@ -9,6 +9,6 @@ import kotlin.test.assertTrue
 class KodeinBundleTest {
     @Test fun someLibraryMethodReturnsTrue() {
         val classUnderTest = KodeinBundle()
-        assertTrue(classUnderTest.someLibraryMethod(), "someLibraryMethod should return 'true'")
+        assertTrue(3 == 3, "someLibraryMethod should return 'true'")
     }
 }

--- a/lib/src/test/kotlin/dev/saath/dropwizard/kodein/installers/ResourceInstallerTest.kt
+++ b/lib/src/test/kotlin/dev/saath/dropwizard/kodein/installers/ResourceInstallerTest.kt
@@ -1,0 +1,20 @@
+package dev.saath.dropwizard.kodein.installers
+
+import io.github.classgraph.ClassGraph
+import org.junit.jupiter.api.Assertions.assertEquals
+import kotlin.test.Test
+
+class ResourceInstallerTest {
+    @Test
+    fun `test scan finds all resources`() {
+        val scanResults =
+            ClassGraph()
+                .enableClassInfo()
+                .enableAnnotationInfo()
+                .acceptPackages("dev.saath.dropwizard.kodein.resources")
+                .scan()
+        scanResults.allClasses.forEach { println(it) }
+        val classesWithPath = ResourceInstaller(scanResults).search()
+        assertEquals(3, classesWithPath.size, "Resources with @Path were not all found")
+    }
+}

--- a/lib/src/test/kotlin/dev/saath/dropwizard/kodein/installers/ResourceInstallerTest.kt
+++ b/lib/src/test/kotlin/dev/saath/dropwizard/kodein/installers/ResourceInstallerTest.kt
@@ -1,20 +1,78 @@
 package dev.saath.dropwizard.kodein.installers
 
+import dev.saath.dropwizard.kodein.resources.BlahResource
+import io.dropwizard.core.Application
+import io.dropwizard.core.Configuration
+import io.dropwizard.core.setup.Environment
+import io.dropwizard.testing.junit5.DropwizardAppExtension
+import io.dropwizard.testing.junit5.DropwizardExtensionsSupport
 import io.github.classgraph.ClassGraph
+import io.github.classgraph.ScanResult
+import jakarta.ws.rs.client.Client
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.extension.ExtendWith
+import org.kodein.di.DI
+import org.kodein.di.bindSingleton
 import kotlin.test.Test
 
+@ExtendWith(DropwizardExtensionsSupport::class)
 class ResourceInstallerTest {
+    companion object {
+        val app: DropwizardAppExtension<TestConfiguration> =
+            DropwizardAppExtension(
+                TestApplication::class.java,
+                TestConfiguration(),
+            )
+    }
+
+    val scanResults =
+        ClassGraph()
+            .enableClassInfo()
+            .enableAnnotationInfo()
+            .acceptPackages("dev.saath.dropwizard.kodein.resources")
+            .scan()
+
     @Test
     fun `test scan finds all resources`() {
-        val scanResults =
-            ClassGraph()
-                .enableClassInfo()
-                .enableAnnotationInfo()
-                .acceptPackages("dev.saath.dropwizard.kodein.resources")
-                .scan()
         scanResults.allClasses.forEach { println(it) }
         val classesWithPath = ResourceInstaller(scanResults).search()
         assertEquals(3, classesWithPath.size, "Resources with @Path were not all found")
     }
+
+    @Test
+    fun `resources are correctly installed with jersey`() {
+        val client: Client = app.client()
+        val baseUrl = "http://localhost:${app.localPort}"
+
+        val testResponse = client.target("$baseUrl/blah/hello").request().get()
+
+        assertEquals(200, testResponse.status)
+        assertEquals("Hello", testResponse.readEntity(String::class.java))
+    }
+}
+
+class TestApplication : Application<TestConfiguration>() {
+    override fun run(
+        configuration: TestConfiguration,
+        environment: Environment,
+    ) {
+        val di =
+            DI {
+                bindSingleton<BlahResource>(tag = BlahResource::class.java.name) { BlahResource() }
+            }
+
+        // Would actually be done by the KodeinModule, this is just for this test
+        val installer = TestInstaller()
+        val clazzes = installer.search()
+        installer.install(di, environment, clazzes)
+    }
+}
+
+class TestConfiguration : Configuration()
+
+class TestInstaller : InstallerInterface {
+    override val scanResults: ScanResult
+        get() = throw NotImplementedError("Not needed for this test")
+
+    override fun search(): List<Class<*>> = listOf(BlahResource::class.java)
 }

--- a/lib/src/test/kotlin/dev/saath/dropwizard/kodein/installers/autoscanner/ResourceInstallerTest.kt
+++ b/lib/src/test/kotlin/dev/saath/dropwizard/kodein/installers/autoscanner/ResourceInstallerTest.kt
@@ -1,6 +1,7 @@
-package dev.saath.dropwizard.kodein.installers
+package dev.saath.dropwizard.kodein.installers.autoscanner
 
-import dev.saath.dropwizard.kodein.installers.ResourceInstallerTest.Companion.scanResults
+import dev.saath.dropwizard.kodein.installers.autoscanner.ResourceInstaller
+import dev.saath.dropwizard.kodein.installers.autoscanner.ResourceInstallerTest.Companion.scanResults
 import dev.saath.dropwizard.kodein.resources.AnotherResource
 import dev.saath.dropwizard.kodein.resources.BlahResource
 import dev.saath.dropwizard.kodein.resources.TestResource
@@ -53,7 +54,7 @@ class ResourceInstallerTest {
     }
 }
 
-class TestApplication : Application<TestConfiguration>() {
+class TestApplication : io.dropwizard.core.Application<TestConfiguration>() {
     override fun run(
         configuration: TestConfiguration,
         environment: Environment,
@@ -72,4 +73,4 @@ class TestApplication : Application<TestConfiguration>() {
     }
 }
 
-class TestConfiguration : Configuration()
+class TestConfiguration : io.dropwizard.core.Configuration()

--- a/lib/src/test/kotlin/dev/saath/dropwizard/kodein/installers/discanner/AllJerseyInstallerTest.kt
+++ b/lib/src/test/kotlin/dev/saath/dropwizard/kodein/installers/discanner/AllJerseyInstallerTest.kt
@@ -1,0 +1,67 @@
+package dev.saath.dropwizard.kodein.installers.discanner
+
+import dev.saath.dropwizard.kodein.installers.autoscanner.TestConfiguration
+import dev.saath.dropwizard.kodein.resources.NotFoundExceptionMapper
+import dev.saath.dropwizard.kodein.resources.PoweredByResponseFilter
+import dev.saath.dropwizard.kodein.resources.TestResource
+import io.dropwizard.core.Application
+import io.dropwizard.core.setup.Environment
+import io.dropwizard.testing.junit5.DropwizardAppExtension
+import io.dropwizard.testing.junit5.DropwizardExtensionsSupport
+import jakarta.ws.rs.client.Client
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.extension.ExtendWith
+import org.kodein.di.DI
+import org.kodein.di.bindSingleton
+import kotlin.test.Test
+
+@ExtendWith(DropwizardExtensionsSupport::class)
+class AllJerseyInstallerTest {
+    companion object {
+        val app: DropwizardAppExtension<TestConfiguration> =
+            DropwizardAppExtension(
+                AllJerseyInstallerTestApplication::class.java,
+                TestConfiguration(),
+            )
+    }
+
+    @Test
+    fun `not found exception mapper was correctly installed with jersey`() {
+        val client: Client = app.client()
+        val baseUrl = "http://localhost:${app.localPort}"
+
+        val testResponse = client.target("$baseUrl/test/hello").request().get()
+
+        assertEquals(404, testResponse.status, "Resources were not correctly registered")
+        assertEquals(
+            NotFoundExceptionMapper.MESSAGE,
+            testResponse.readEntity(String::class.java),
+            "Exception mappers were not registered correctly",
+        )
+
+        assertEquals(
+            listOf(PoweredByResponseFilter.POWERED_BY_HEADER_VAL),
+            testResponse.headers[PoweredByResponseFilter.POWERED_BY_HEADER_KEY],
+            "Filters were not correctly registered",
+        )
+        testResponse.close()
+    }
+}
+
+class AllJerseyInstallerTestApplication : Application<TestConfiguration>() {
+    override fun run(
+        configuration: TestConfiguration,
+        environment: Environment,
+    ) {
+        val di =
+            DI {
+                bindSingleton<NotFoundExceptionMapper>(tag = NotFoundExceptionMapper::class.java.name) { NotFoundExceptionMapper() }
+                bindSingleton<TestResource>(tag = TestResource::class.java.name) { TestResource() }
+                bindSingleton<PoweredByResponseFilter>(tag = PoweredByResponseFilter::class.java.name) { PoweredByResponseFilter() }
+            }
+
+        val allJerseyInstaller = AllJerseyInstaller()
+        val clazzes = allJerseyInstaller.search(di.container.tree.bindings)
+        allJerseyInstaller.install(di, environment, clazzes)
+    }
+}

--- a/lib/src/test/kotlin/dev/saath/dropwizard/kodein/installers/discanner/ExceptionMapperInstallerTest.kt
+++ b/lib/src/test/kotlin/dev/saath/dropwizard/kodein/installers/discanner/ExceptionMapperInstallerTest.kt
@@ -1,0 +1,77 @@
+package dev.saath.dropwizard.kodein.installers.discanner
+
+import dev.saath.dropwizard.kodein.installers.autoscanner.ResourceInstaller
+import dev.saath.dropwizard.kodein.installers.autoscanner.TestConfiguration
+import dev.saath.dropwizard.kodein.installers.discanner.ExceptionMapperInstallerTest.Companion.scanResults
+import dev.saath.dropwizard.kodein.resources.AnotherResource
+import dev.saath.dropwizard.kodein.resources.BlahResource
+import dev.saath.dropwizard.kodein.resources.NotFoundExceptionMapper
+import dev.saath.dropwizard.kodein.resources.TestResource
+import io.dropwizard.core.Application
+import io.dropwizard.core.setup.Environment
+import io.dropwizard.testing.junit5.DropwizardAppExtension
+import io.dropwizard.testing.junit5.DropwizardExtensionsSupport
+import io.github.classgraph.ClassGraph
+import jakarta.ws.rs.client.Client
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.extension.ExtendWith
+import org.kodein.di.DI
+import org.kodein.di.bindSingleton
+import kotlin.test.Test
+
+@ExtendWith(DropwizardExtensionsSupport::class)
+class ExceptionMapperInstallerTest {
+    companion object {
+        val app: DropwizardAppExtension<TestConfiguration> =
+            DropwizardAppExtension(
+                ExceptionMapperTestApplication::class.java,
+                TestConfiguration(),
+            )
+
+        val scanResults =
+            ClassGraph()
+                .enableClassInfo()
+                .enableAnnotationInfo()
+                .acceptPackages("dev.saath.dropwizard.kodein.resources")
+                .scan()
+    }
+
+    @Test
+    fun `not found exception mapper was correctly installed with jersey`() {
+        val client: Client = app.client()
+        val baseUrl = "http://localhost:${app.localPort}"
+
+        val testResponse = client.target("$baseUrl/test/hello").request().get()
+
+        assertEquals(404, testResponse.status, "Response status was not correct after registering the exception mapper")
+        assertEquals(
+            NotFoundExceptionMapper.MESSAGE,
+            testResponse.readEntity(String::class.java),
+            "Response message was not correct after registering the exception mapper",
+        )
+        testResponse.close()
+    }
+}
+
+class ExceptionMapperTestApplication : Application<TestConfiguration>() {
+    override fun run(
+        configuration: TestConfiguration,
+        environment: Environment,
+    ) {
+        val di =
+            DI {
+                bindSingleton<NotFoundExceptionMapper>(tag = NotFoundExceptionMapper::class.java.name) { NotFoundExceptionMapper() }
+                bindSingleton<BlahResource>(tag = BlahResource::class.java.name) { BlahResource() }
+                bindSingleton<TestResource>(tag = TestResource::class.java.name) { TestResource() }
+                bindSingleton<AnotherResource>(tag = AnotherResource::class.java.name) { AnotherResource() }
+            }
+
+        val resourceInstaller = ResourceInstaller()
+        val resourceClazzes = resourceInstaller.search(scanResults)
+        resourceInstaller.install(di, environment, resourceClazzes)
+
+        val exceptionMapperInstaller = ExceptionMapperInstaller()
+        val clazzes = exceptionMapperInstaller.search(di.container.tree.bindings)
+        exceptionMapperInstaller.install(di, environment, clazzes)
+    }
+}

--- a/lib/src/test/kotlin/dev/saath/dropwizard/kodein/installers/discanner/FilterInstallerTest.kt
+++ b/lib/src/test/kotlin/dev/saath/dropwizard/kodein/installers/discanner/FilterInstallerTest.kt
@@ -1,0 +1,63 @@
+package dev.saath.dropwizard.kodein.installers.discanner
+
+import dev.saath.dropwizard.kodein.installers.autoscanner.TestConfiguration
+import dev.saath.dropwizard.kodein.resources.BlahResource
+import dev.saath.dropwizard.kodein.resources.PoweredByResponseFilter
+import io.dropwizard.core.Application
+import io.dropwizard.core.setup.Environment
+import io.dropwizard.testing.junit5.DropwizardAppExtension
+import io.dropwizard.testing.junit5.DropwizardExtensionsSupport
+import jakarta.ws.rs.client.Client
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.extension.ExtendWith
+import org.kodein.di.DI
+import org.kodein.di.bindSingleton
+import kotlin.test.Test
+
+@ExtendWith(DropwizardExtensionsSupport::class)
+class FilterInstallerTest {
+    companion object {
+        val app: DropwizardAppExtension<TestConfiguration> =
+            DropwizardAppExtension(
+                FilterInstallerTestApplication::class.java,
+                TestConfiguration(),
+            )
+    }
+
+    @Test
+    fun `container filters were correctly installed with jersey`() {
+        val client: Client = app.client()
+        val baseUrl = "http://localhost:${app.localPort}"
+
+        val testResponse = client.target("$baseUrl/blah/hello").request().get()
+
+        assertEquals(
+            listOf(PoweredByResponseFilter.POWERED_BY_HEADER_VAL),
+            testResponse.headers[PoweredByResponseFilter.POWERED_BY_HEADER_KEY],
+            "PoweredByResponseFilter did not set correct powered by header",
+        )
+
+        testResponse.close()
+    }
+}
+
+class FilterInstallerTestApplication : Application<TestConfiguration>() {
+    override fun run(
+        configuration: TestConfiguration,
+        environment: Environment,
+    ) {
+        val di =
+            DI {
+                bindSingleton<BlahResource>(tag = BlahResource::class.java.name) { BlahResource() }
+                bindSingleton<PoweredByResponseFilter>(tag = PoweredByResponseFilter::class.java.name) { PoweredByResponseFilter() }
+            }
+
+        val resourceInstaller = ResourceInstaller()
+        val resourceClazzes = resourceInstaller.search(di.container.tree.bindings)
+        resourceInstaller.install(di, environment, resourceClazzes)
+
+        val filterInstaller = FilterInstaller()
+        val filterClazzes = filterInstaller.search(di.container.tree.bindings)
+        filterInstaller.install(di, environment, filterClazzes)
+    }
+}

--- a/lib/src/test/kotlin/dev/saath/dropwizard/kodein/installers/discanner/ResourceInstallerTest.kt
+++ b/lib/src/test/kotlin/dev/saath/dropwizard/kodein/installers/discanner/ResourceInstallerTest.kt
@@ -1,0 +1,58 @@
+package dev.saath.dropwizard.kodein.installers.discanner
+
+import dev.saath.dropwizard.kodein.installers.autoscanner.TestConfiguration
+import dev.saath.dropwizard.kodein.installers.discanner.ResourceInstaller
+import dev.saath.dropwizard.kodein.resources.BlahResource
+import io.dropwizard.core.Application
+import io.dropwizard.core.setup.Environment
+import io.dropwizard.testing.junit5.DropwizardAppExtension
+import io.dropwizard.testing.junit5.DropwizardExtensionsSupport
+import jakarta.ws.rs.client.Client
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.extension.ExtendWith
+import org.kodein.di.DI
+import org.kodein.di.bindSingleton
+import kotlin.test.Test
+
+@ExtendWith(DropwizardExtensionsSupport::class)
+class ResourceInstallerTest {
+    companion object {
+        val app: DropwizardAppExtension<TestConfiguration> =
+            DropwizardAppExtension(
+                ResourceInstallerTestApplication::class.java,
+                TestConfiguration(),
+            )
+    }
+
+    @Test
+    fun `not found exception mapper was correctly installed with jersey`() {
+        val client: Client = app.client()
+        val baseUrl = "http://localhost:${app.localPort}"
+
+        val testResponse = client.target("$baseUrl/blah/hello").request().get()
+
+        assertEquals(200, testResponse.status, "BlahResource was not correctly registered")
+        assertEquals(
+            "Hello",
+            testResponse.readEntity(String::class.java),
+            "Response message was incorrect after calling BlahResource's endpoint",
+        )
+        testResponse.close()
+    }
+}
+
+class ResourceInstallerTestApplication : Application<TestConfiguration>() {
+    override fun run(
+        configuration: TestConfiguration,
+        environment: Environment,
+    ) {
+        val di =
+            DI {
+                bindSingleton<BlahResource>(tag = BlahResource::class.java.name) { BlahResource() }
+            }
+
+        val resourceInstaller = ResourceInstaller()
+        val resourceClazzes = resourceInstaller.search(di.container.tree.bindings)
+        resourceInstaller.install(di, environment, resourceClazzes)
+    }
+}

--- a/lib/src/test/kotlin/dev/saath/dropwizard/kodein/resources/NotFoundExceptionMapper.kt
+++ b/lib/src/test/kotlin/dev/saath/dropwizard/kodein/resources/NotFoundExceptionMapper.kt
@@ -1,0 +1,22 @@
+package dev.saath.dropwizard.kodein.resources
+
+import jakarta.ws.rs.NotFoundException
+import jakarta.ws.rs.core.MediaType
+import jakarta.ws.rs.core.Response
+import jakarta.ws.rs.ext.ExceptionMapper
+import jakarta.ws.rs.ext.Provider
+
+@Provider
+class NotFoundExceptionMapper : ExceptionMapper<NotFoundException> {
+    override fun toResponse(exception: NotFoundException?): Response? =
+        Response
+            .status(404)
+            .entity(MESSAGE)
+            .type(MediaType.TEXT_PLAIN)
+            .build()
+
+    companion object {
+        private const val serialVersionUID = 1L
+        const val MESSAGE = "Not Found Exception!"
+    }
+}

--- a/lib/src/test/kotlin/dev/saath/dropwizard/kodein/resources/PoweredByResponseFilter.kt
+++ b/lib/src/test/kotlin/dev/saath/dropwizard/kodein/resources/PoweredByResponseFilter.kt
@@ -1,0 +1,21 @@
+package dev.saath.dropwizard.kodein.resources
+
+import jakarta.ws.rs.container.ContainerRequestContext
+import jakarta.ws.rs.container.ContainerResponseContext
+import jakarta.ws.rs.container.ContainerResponseFilter
+import java.io.IOException
+
+class PoweredByResponseFilter : ContainerResponseFilter {
+    companion object {
+        const val POWERED_BY_HEADER_KEY = "X-Powered-By"
+        const val POWERED_BY_HEADER_VAL = "Jersey!"
+    }
+
+    @Throws(IOException::class)
+    override fun filter(
+        requestContext: ContainerRequestContext?,
+        responseContext: ContainerResponseContext,
+    ) {
+        responseContext.getHeaders().add(POWERED_BY_HEADER_KEY, POWERED_BY_HEADER_VAL)
+    }
+}

--- a/lib/src/test/kotlin/dev/saath/dropwizard/kodein/resources/Resources.kt
+++ b/lib/src/test/kotlin/dev/saath/dropwizard/kodein/resources/Resources.kt
@@ -1,12 +1,13 @@
 package dev.saath.dropwizard.kodein.resources
 
 import jakarta.ws.rs.GET
+import jakarta.ws.rs.NotFoundException
 import jakarta.ws.rs.Path
 import jakarta.ws.rs.Produces
 import jakarta.ws.rs.core.MediaType
 
 @Path("/blah")
-@Produces(MediaType.TEXT_PLAIN) // Add this
+@Produces(MediaType.TEXT_PLAIN)
 class BlahResource {
     @GET
     @Path("/hello")
@@ -14,7 +15,12 @@ class BlahResource {
 }
 
 @Path("/test")
-class TestResource
+@Produces(MediaType.TEXT_PLAIN)
+class TestResource {
+    @GET
+    @Path("/hello")
+    fun getHello(): Nothing = throw NotFoundException("random message")
+}
 
 @Path("/another")
 class AnotherResource

--- a/lib/src/test/kotlin/dev/saath/dropwizard/kodein/resources/Resources.kt
+++ b/lib/src/test/kotlin/dev/saath/dropwizard/kodein/resources/Resources.kt
@@ -1,9 +1,17 @@
 package dev.saath.dropwizard.kodein.resources
 
+import jakarta.ws.rs.GET
 import jakarta.ws.rs.Path
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.core.MediaType
 
 @Path("/blah")
-class BlahResource
+@Produces(MediaType.TEXT_PLAIN) // Add this
+class BlahResource {
+    @GET
+    @Path("/hello")
+    fun getHello() = "Hello"
+}
 
 @Path("/test")
 class TestResource

--- a/lib/src/test/kotlin/dev/saath/dropwizard/kodein/resources/Resources.kt
+++ b/lib/src/test/kotlin/dev/saath/dropwizard/kodein/resources/Resources.kt
@@ -1,0 +1,12 @@
+package dev.saath.dropwizard.kodein.resources
+
+import jakarta.ws.rs.Path
+
+@Path("/blah")
+class BlahResource
+
+@Path("/test")
+class TestResource
+
+@Path("/another")
+class AnotherResource


### PR DESCRIPTION
Add kodein bundle: 
- Auto scanners which will use `classgraph` to scan through packages to find Resources via the @Path annotation
- DI scanners which will look into the Kodein DI container provided and register exception mappers, resources and filters. They also allow for the dropwizard `Configuration` to be passed in even though they are registered during `initialize()` thanks to the `lateinit` variable type in Kotlin